### PR TITLE
Remove merge artifacts from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,6 @@
 .Rhistory
 .RData
 .Ruserdata
-<<<<<<< HEAD
 results/*
 data/FungicideTidy.csv
 .httr-oauth
-=======
->>>>>>> 2933c319ce2c29298feb2fbd6acdf750c5e02bf0


### PR DESCRIPTION
commit 1ca0b9ba23884711518233e3884ff068d0859953 was a merge commit, which had conflicts in the `.gitignore` file. This was not addressed at the merge, so I'm addressing them now.